### PR TITLE
breaking(Android): replace deprecated repository: jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ description = 'react-native-pdf'
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 
@@ -12,11 +12,11 @@ buildscript {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
     maven {
         url 'https://jitpack.io'
         content {
-            // Use Jitpack only for AndroidPdfViewer; the rest is hosted at jcenter.
+            // Use Jitpack only for AndroidPdfViewer; the rest is hosted at mavenCentral.
             includeGroup "com.github.TalbotGooday"
         }
     }

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath("com.android.tools.build:gradle:3.4.1")
@@ -33,6 +33,6 @@ allprojects {
         }
 
         google()
-        jcenter()
+        mavenCentral()
     }
 }


### PR DESCRIPTION
`jcenter()` is deprecated, so it should be replaced by `mavenCentral()`
https://blog.gradle.org/jcenter-shutdown